### PR TITLE
Add note about encrypted Travis secrets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Note: secrets in this file are encrypted
+# See: https://docs.travis-ci.com/user/encryption-keys/ for details
+
 language: go
 go: '1.7'
 install:


### PR DESCRIPTION
The secrets in the .travis.yml file are encrypted, and can't be used without decryption. This is not clear from the first look at the file. Adding a note which points this out, also adding a note to the documentation for encryption keys.